### PR TITLE
Update thrust_map.h + type inquiry

### DIFF
--- a/include/thrust_map.h
+++ b/include/thrust_map.h
@@ -1,13 +1,13 @@
 /**
  * @headerfile thrust_map.h
  *
- * @brief      Functions to start and stop the printf mnaager which is a
+ * @brief      Functions to start and stop the printf manager which is a
  *             separate thread printing data to the console for debugging.
  */
 
 
-#ifndef THURST_MAP_H
-#define THURST_MAP_H
+#ifndef THRUST_MAP_H
+#define THRUST_MAP_H
 
 #include <thrust_map_defs.h>
 
@@ -15,7 +15,7 @@
  * @brief      Check the thrust map for validity and populate data arrays.
  *
  *
- * @param[in]  map   The map
+ * @param[in]  map   The thrust map to be used
  *
  * @return     0 on success, -1 on failure
  */
@@ -25,10 +25,10 @@ int initialize_thrust_map(thrust_map_t map);
  * @brief      Corrects the motor signal m for non-linear thrust curve in place.
  *
  *
- * @param[in]  m     { parameter_description }
+ * @param[in]  m     thrust input, must be between 0 and 1 inclusive
  *
- * @return     0 on success, -1 on error
+ * @return     motor signal value on success, -1 on error
  */
 float map_motor_signal(float m);
 
-#endif // THURST_MAP_H
+#endif // THRUST_MAP_H


### PR DESCRIPTION
updated parameter descriptions in documentation, a few typos, and a type mismatch. 

for method map_motor_signal(float m), the same method in the associated c file thrust_map.c takes and returns doubles, not floats. look into this